### PR TITLE
Improved RNRFActions interface definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -269,7 +269,8 @@ declare namespace RNRF {
     jump(props: props): void,
     refresh(props: props): void,
     focus(props: props): void,
-    create(scene: React.ReactNode, wrapBy?: () => any): Object
+    create(scene: React.ReactNode, wrapBy?: () => any): Object,
+    [sceneKey: string]: (props?: props) => void
   }
 
   export var Actions: RNRFActions;


### PR DESCRIPTION
I've improved the RNRFActions interface definition so that the Actions object is indexable by key. In code, we can then use `Actions["mySuperAwesomeScene"]()` to make a transition. Better yet, you can create an enum (e.g. `Scenes` and corresponding `getKey` function) and use it like this: `Actions[getKey(Scenes.Register)]();`
